### PR TITLE
Added missing break

### DIFF
--- a/jquery.strengthify.js
+++ b/jquery.strengthify.js
@@ -107,6 +107,7 @@
                         css = 'password-good';
                         bsLevel = 'info';
                         message = "Getting better.";
+                        break;
                     case 4:
                         css = 'password-good';
                         bsLevel = 'success';


### PR DESCRIPTION
Fixed issue where the meter won't show score 3, jumping directly to score 4 case, because of missing break.
